### PR TITLE
Remove Typescript projects and publish logic

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,6 +2,3 @@ rootProject.name = 'witchcraft-api'
 
 include 'witchcraft-health-api'
 include 'witchcraft-logging-api'
-
-include 'witchcraft-logging-api:witchcraft-logging-api-typescript'
-include 'witchcraft-health-api:witchcraft-health-api-typescript'

--- a/versions.props
+++ b/versions.props
@@ -1,2 +1,1 @@
 com.palantir.conjure:conjure = 4.4.0
-com.palantir.conjure.typescript:* = 3.4.0

--- a/witchcraft-health-api/build.gradle
+++ b/witchcraft-health-api/build.gradle
@@ -1,14 +1,2 @@
 apply plugin: 'com.palantir.conjure-publish'
 apply from: "$rootDir/gradle/publish-conjure.gradle"
-
-project (':witchcraft-health-api:witchcraft-health-api-typescript') {
-    publishTypeScript.doFirst {
-        file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
-    }
-}
-
-conjure {
-    typescript {
-        nodeCompatibleModules = true
-    }
-}

--- a/witchcraft-health-api/witchcraft-health-api-typescript/.gitignore
+++ b/witchcraft-health-api/witchcraft-health-api-typescript/.gitignore
@@ -1,6 +1,0 @@
-*.js
-*.ts
-.npmrc
-package.json
-tsconfig.json
-node_modules

--- a/witchcraft-logging-api/build.gradle
+++ b/witchcraft-logging-api/build.gradle
@@ -1,14 +1,2 @@
 apply plugin: 'com.palantir.conjure-publish'
 apply from: "$rootDir/gradle/publish-conjure.gradle"
-
-project (':witchcraft-logging-api:witchcraft-logging-api-typescript') {
-    publishTypeScript.doFirst {
-        file('src/.npmrc') << "//registry.npmjs.org/:_authToken=${System.env.NPM_AUTH_TOKEN}"
-    }
-}
-
-conjure {
-    typescript {
-        nodeCompatibleModules = true
-    }
-}

--- a/witchcraft-logging-api/witchcraft-logging-api-typescript/.gitignore
+++ b/witchcraft-logging-api/witchcraft-logging-api-typescript/.gitignore
@@ -1,6 +1,0 @@
-*.js
-*.ts
-.npmrc
-package.json
-tsconfig.json
-node_modules


### PR DESCRIPTION
The current setup doesn't work, so this commit removes the Typescript
portions completely. At a future point when the published definitions
from this repository are required, they can be added back in properly.