### PR TITLE
Add UNKNOWN health variant

### DIFF
--- a/witchcraft-health-api/src/main/conjure/witchcraft-health-api.yml
+++ b/witchcraft-health-api/src/main/conjure/witchcraft-health-api.yml
@@ -59,3 +59,6 @@ types:
               The service node has entered an unrecoverable state.
               All nodes of the service should be stopped and no automated attempt to restart the node should be made.
               Ex: a service fails to migrate to a new schema and is left in an unrecoverable state.
+          - value: UNKNOWN
+            docs: >
+              The service node's health status could not be collected.


### PR DESCRIPTION
The health spec defines `UNKNOWN` as a valid value. Before https://github.com/palantir/conjure-go/pull/139, we were using the catch-all `HealthStateUnknown` to represent this.

Since that placeholder value has been removed, add back a real enum value for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-api/151)
<!-- Reviewable:end -->
