### PR TITLE
Add organization ID to logs

### DIFF
--- a/changelog/@unreleased/pr-663.v2.yml
+++ b/changelog/@unreleased/pr-663.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: All logs now include an `orgId` field.
+  links:
+  - https://github.com/palantir/witchcraft-api/pull/663

--- a/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
+++ b/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
@@ -89,6 +89,9 @@ types:
           tokenId:
             type: optional<TokenId>
             docs: API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: Zipkin trace id (if available)
@@ -158,6 +161,9 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: |
@@ -228,6 +234,9 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: |
@@ -245,6 +254,7 @@ types:
           uid: optional<UserId>
           sid: optional<SessionId>
           tokenId: optional<TokenId>
+          orgId: optional<OrganizationId>
           unsafeParams: map<string, any>
           span: Span
       Span:
@@ -335,6 +345,10 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: |
+              Organization id (if available)
           unsafeParams:
             type: map<string, any>
             docs: |
@@ -364,6 +378,10 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: |
+              Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: |
@@ -408,6 +426,10 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: |
+              Organization id (if available)
           unsafeParams:
             type: map<string, any>
             docs: |
@@ -432,6 +454,10 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: |
+              Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: |
@@ -560,6 +586,10 @@ types:
             type: optional<TokenId>
             docs: |
               API token id (if available)
+          orgId:
+            type: optional<OrganizationId>
+            docs: |
+              Organization id (if available)
           traceId:
             type: optional<TraceId>
             docs: |
@@ -586,10 +616,10 @@ types:
       Organization:
         fields:
           id:
-            docs: Organization ID. Not exposed to downstream consumers.
+            docs: Organization RID. Not exposed to downstream consumers.
             type: string
           reason:
-            docs: Explaination of why this organization was attributed to this log.
+            docs: Explanation of why this organization was attributed to this log.
             type: string
       ContextualizedUser:
         fields:
@@ -716,6 +746,8 @@ types:
       SessionId:
         alias: string
       TokenId:
+        alias: string
+      OrganizationId:
         alias: string
       TraceId:
         alias: string


### PR DESCRIPTION
There is a desire to be able to attribute logs to individual organizations. The easiest way to do this is for it to be automatically included by our logging infra.

In https://github.com/palantir/auth-tokens/pull/806 we updated UnverifiedJsonWebToken to support extracting this claim.