### PR TITLE
Update AuditLogV3 to switch to less-nested fields by removing unusable SensitivityTaggedValue levels in a non-breaking way

### DIFF
--- a/changelog/@unreleased/pr-831.v2.yml
+++ b/changelog/@unreleased/pr-831.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Update AuditLogV3 to switch to less-nested fields by removing unusable SensitivityTaggedValue levels in a non-breaking way.
+  links:
+  - https://github.com/palantir/witchcraft-api/pull/831

--- a/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
+++ b/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
@@ -560,19 +560,37 @@ types:
 
               This value is verified through the TCP stack.
           requestParams:
-            type: map<string, SensitivityTaggedValue>
-            docs: |
-              The parameters known at method invocation time.
+            deprecated: |
+              Use requestFields instead.
 
-              Note that all keys must be known to the audit library. Typically, entries in the request and response
-              params will be dependent on the `categories` field defined above.
-          resultParams:
+              Should be translated to requestFields during emitting if requestFields is missing, by dropping the level
+              from the SensitivityTaggedValue and directly using the payload as the value for the map.
             type: map<string, SensitivityTaggedValue>
+          requestFields:
+            type: map<string, any>
+            docs: |
+              The fields known at method invocation time.
+
+              Note that all keys must be known to the audit library. Typically, entries in the request and result
+              fields will be dependent on the `categories` field defined above.
+
+              This replaces requestParams and will take priority if present.
+          resultParams:
+            deprecated: |
+              Use resultFields instead.
+
+              Should be translated to resultFields during emitting if resultFields is missing, by dropping the level
+              from the SensitivityTaggedValue and directly using the payload as the value for the map.
+            type: map<string, SensitivityTaggedValue>
+          resultFields:
+            type: map<string, any>
             docs: |
               Information derived within a method, commonly parts of the return value.
 
-              Note that all keys must be known to the audit library. Typically, entries in the request and response
-              params will be dependent on the `categories` field defined above.
+              Note that all keys must be known to the audit library. Typically, entries in the request and result
+              fields will be dependent on the `categories` field defined above.
+
+              This replaces resultParams and will take priority if present.
           time: datetime
           uid:
             type: optional<UserId>


### PR DESCRIPTION
In practice, SensitivityTaggedValue.level was always being set to unknown, which makes the nesting somewhat pointless. Adding new, unnested fields here in support of eventually removing the old ones entirely without breaking consumers in the meantime.