### PR TITLE
Add svc to event and audit logs

### DIFF
--- a/changelog/@unreleased/pr-svc.v2.yml
+++ b/changelog/@unreleased/pr-svc.v2.yml
@@ -1,0 +1,5 @@
+type: feature
+feature:
+  description: Event and audit logs now include a `svc` field.
+  links:
+  - https://github.com/palantir/witchcraft-api/pull/1187

--- a/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
+++ b/witchcraft-logging-api/src/main/conjure/witchcraft-logging-api.yml
@@ -381,6 +381,9 @@ types:
           orgId:
             type: optional<OrganizationId>
             docs: Organization id (if available)
+          svc:
+            type: optional<Service>
+            docs: Service (if available). This is the most downstream calling service.
           traceId:
             type: optional<TraceId>
             docs: |
@@ -459,6 +462,9 @@ types:
           orgId:
             type: optional<OrganizationId>
             docs: Organization id (if available)
+          svc:
+            type: optional<Service>
+            docs: Service (if available). This is the most downstream calling service.
           traceId:
             type: optional<TraceId>
             docs: |
@@ -627,6 +633,9 @@ types:
           orgId:
             type: optional<OrganizationId>
             docs: Organization id (if available)
+          svc:
+            type: optional<Service>
+            docs: Service (if available). This is the most downstream calling service.
           traceId:
             type: optional<TraceId>
             docs: |
@@ -798,6 +807,8 @@ types:
       TokenId:
         alias: string
       TraceId:
+        alias: string
+      Service:
         alias: string
 
       WitchcraftEnvelopeV1:


### PR DESCRIPTION
There is a desire to be able to attribute event and audit logs to service users. The easiest way to do this is for it to be automatically included by our logging infra.

The svc field is now present in:
- EventLogV2
- AuditLogV2, AuditLogV3

In https://github.com/palantir/auth-tokens/pull/1331, we updated UnverifiedJsonWebToken to support extracting this claim.